### PR TITLE
Organize documentation for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ uv pip install -e .
 
 ## Documentation
 
+Browse the full documentation site at
+[earthlab.github.io/cross-sensor-cal](https://earthlab.github.io/cross-sensor-cal).
+The site is built with MkDocs Material and automatically deployed to GitHub
+Pages.
+
+Key entry points:
+
 - [Overview](docs/overview.md)
 - [Quickstart](docs/quickstart.md)
 - [Stage 01 Raster Processing](docs/stage-01-raster-processing.md)

--- a/docs/documentation-overview.md
+++ b/docs/documentation-overview.md
@@ -23,4 +23,3 @@ defines how you should write and maintain docs across the repository.
 Expand this folder with API references, architecture diagrams, or tutorials as
 the project evolves.
 
-Last updated: 2025-08-14

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+# Cross-Sensor Calibration
+
+Welcome to the Cross-Sensor Calibration knowledge base. This site explains how
+we transform raw NEON Airborne Observation Platform (AOP) hyperspectral
+flightlines into analysis-ready products that emulate a range of alternative
+sensors.
+
+The documentation is organized around the production pipeline and is intended
+for researchers, analysts, and developers who need reproducible spectral
+processing workflows.
+
+## What you will find here
+
+- **Quickstarts** to help you install the tooling and run the pipeline on a test
+  flightline.
+- **Stage-by-stage guides** that detail every processing step from raster
+  correction through MESMA analysis.
+- **Configuration and reference material** that describes data schemas, naming
+  conventions, and validation checks.
+- **Troubleshooting tips** and frequently asked questions for when things do not
+  go as expected.
+
+## First steps
+
+1. Read the [project overview](overview.md) for the big picture.
+2. Follow the [quickstart](quickstart.md) to process a minimal dataset end to
+   end.
+3. Review the [environment setup](env-setup.md) instructions before tackling a
+   full production run.
+
+## Pipeline at a glance
+
+```mermaid
+flowchart LR
+    R[Stage 01\nRaster Processing]
+    S[Stage 02\nSorting]
+    P[Stage 03\nPixel Extraction]
+    L[Stage 04\nSpectral Library]
+    M[Stage 05\nMESMA]
+    R --> S --> P --> L --> M
+```
+
+Each stage consumes artifacts from the previous one and exports outputs that are
+ready for the next step. Dive into the dedicated pages in the pipeline section
+for detailed instructions, expected inputs, and generated products.
+
+## Need help?
+
+If you get stuck or have feedback about the documentation, open an issue on the
+[GitHub repository](https://github.com/earthlab/cross-sensor-cal/issues).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,36 +1,60 @@
-# <!-- FILLME:START -->
-site_name: Cross Sensor Cal
+site_name: Cross Sensor Calibration
+site_description: >-
+  Documentation for the Cross-Sensor Calibration pipeline that processes NEON
+  AOP hyperspectral flightlines into analysis-ready products.
+site_url: https://earthlab.github.io/cross-sensor-cal
+repo_name: earthlab/cross-sensor-cal
 repo_url: https://github.com/earthlab/cross-sensor-cal
+
 theme:
   name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - toc.integrate
+    - content.code.copy
+
 plugins:
   - search
   - mkdocstrings
+
 markdown_extensions:
   - admonition
-  - toc:
-      permalink: true
   - footnotes
   - tables
-nav:
-  - Overview: overview.md
-  - Quickstart: quickstart.md
-  - Environment Setup: env-setup.md
-  - CyVerse iRODS: cyverse-irods.md
-  - Configuration: configuration.md
-  - Naming Conventions: naming-conventions.md
-  - Schemas: schemas.md
-  - Stage 01 Raster Processing: stage-01-raster-processing.md
-  - Stage 02 Sorting: stage-02-sorting.md
-  - Stage 03 Pixel Extraction: stage-03-pixel-extraction.md
-  - Stage 04 Spectral Library: stage-04-spectral-library.md
-  - Stage 05 MESMA: stage-05-mesma.md
-  - Validation: validation.md
-  - Benchmarks: benchmarks.md
-  - Troubleshooting: troubleshooting.md
-  - FAQ: faq.md
-  - Extending: extending.md
-  - Glossary: glossary.md
-  - References: references.md
-# <!-- FILLME:END -->
+  - toc:
+      permalink: true
+  - attr_list
+  - pymdownx.details
+  - pymdownx.superfences
 
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Overview: overview.md
+      - Quickstart: quickstart.md
+      - Environment Setup: env-setup.md
+      - CyVerse iRODS: cyverse-irods.md
+      - Configuration: configuration.md
+      - Naming Conventions: naming-conventions.md
+      - Schemas: schemas.md
+  - Pipeline:
+      - Stage 01 · Raster Processing: stage-01-raster-processing.md
+      - Stage 02 · Sorting: stage-02-sorting.md
+      - Stage 03 · Pixel Extraction: stage-03-pixel-extraction.md
+      - Stage 04 · Spectral Library: stage-04-spectral-library.md
+      - Stage 05 · MESMA: stage-05-mesma.md
+  - Validation & Support:
+      - Validation: validation.md
+      - Benchmarks: benchmarks.md
+      - Troubleshooting: troubleshooting.md
+      - FAQ: faq.md
+  - Guides & References:
+      - Extending the Pipeline: extending.md
+      - Documentation Style Guide: documentation_style_guide.md
+      - Dev Notes: dev-notes.md
+      - Glossary: glossary.md
+      - References: references.md
+      - Onboarding:
+          - Sorting and Retrieval Overview: onboarding/sorting_and_retrieval_overview.md


### PR DESCRIPTION
## Summary
- add a dedicated MkDocs homepage and restructure navigation to match the hosted site layout
- update the README with the GitHub Pages link and rename the documentation overview file to avoid conflicts
- enable additional Material theme features and Markdown extensions for diagrams and collapsible details

## Testing
- mkdocs build --strict

------
https://chatgpt.com/codex/tasks/task_e_68ded22d4ab8832596638feef300788f