### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- configure the GitHub Pages workflow with actions/configure-pages so MkDocs output is deployed instead of the repository README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ded45fe3948325877b174f05ae79cf