### PR TITLE
Enable Mermaid diagrams on homepage

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,11 @@ markdown_extensions:
       permalink: true
   - attr_list
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- configure pymdownx.superfences with a mermaid custom fence so Mermaid diagrams render in the docs

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68ded86713c483259d49fb8881a887d5