### PR TITLE
Skip convolution resampling for mask-only ENVI files

### DIFF
--- a/src/convolution_resample.py
+++ b/src/convolution_resample.py
@@ -66,6 +66,9 @@ def resample(input_dir: Path):
 
 
     for hdr_file in brdf_corrected_hdr_files:
+        if "mask" in (hdr_file.suffix or "").lower():
+            print(f"ℹ️ Skipping mask file without spectral bands: {hdr_file.file_path}")
+            continue
         try:
             print(f"📂 Opening: {hdr_file.file_path}")
             img = open_image(hdr_file.file_path)


### PR DESCRIPTION
## Summary
- skip BRDF mask ENVI headers when running convolution resampling to avoid band mismatch errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00b25d61483258b56b47c899fee3a