### PR TITLE
Suppress Ray object store warning during ENVI conversion

### DIFF
--- a/bin/neon_to_envi.py
+++ b/bin/neon_to_envi.py
@@ -1,6 +1,12 @@
+import os
 import sys
 import argparse
 from pathlib import Path
+
+# Silence Ray's shared-memory warning about falling back to /tmp. This reduces
+# noisy log output while keeping the default behavior intact.
+os.environ.setdefault("RAY_DISABLE_OBJECT_STORE_WARNING", "1")
+
 import ray
 import hytools as ht
 

--- a/src/neon_to_envi.py
+++ b/src/neon_to_envi.py
@@ -3,6 +3,10 @@ import argparse
 import h5py
 import shutil
 from h5py import Dataset
+
+# Suppress Ray's /dev/shm fallback warning to keep conversion logs clean.
+os.environ.setdefault("RAY_DISABLE_OBJECT_STORE_WARNING", "1")
+
 import ray
 import numpy as np
 from pathlib import Path


### PR DESCRIPTION
## Summary
- silence Ray's shared-memory fallback warning in the CLI and library ENVI conversion scripts
- keep conversion logs focused on user-facing progress messages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e010a81f308325b94dbe2c0fc343c4