### PR TITLE
Fix DataFile.file_path to return Path objects

### DIFF
--- a/src/file_types.py
+++ b/src/file_types.py
@@ -43,8 +43,9 @@ class DataFile:
         return self.path.parent
 
     @property
-    def file_path(self) -> str:
-        return str(self.path)
+    def file_path(self) -> Path:
+        """Return the concrete :class:`Path` for this data file."""
+        return self.path
 
     @classmethod
     def match(cls, filename: str) -> Optional[re.Match]:


### PR DESCRIPTION
## Summary
- ensure DataFile.file_path returns the underlying Path so callers can access Path utilities

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68e0293366d083259caa034fb19d9e45