### PR TITLE
Add pyproject build configuration and setup shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cross_sensor_cal"
+version = "0.1.0"
+description = "Cross-sensor calibration pipeline."
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{ name = "Earth Lab" }]
+license = { file = "LICENSE" }
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,23 @@
-from setuptools import setup, find_packages
+"""Compatibility shim for legacy installation workflows.
 
-setup(
-    name="cross_sensor_cal",
-    version="0.1",
-    packages=find_packages(where="src"),  # Tells pip to look inside src/
-    package_dir={"": "src"},              # Maps "src" to the package root
-)
+This project is configured as a PEP 517/660 package using ``pyproject.toml``.
+Direct execution of ``setup.py`` is no longer supported. Please install the
+package in editable mode with ``pip install -e .``.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    message = (
+        "This project uses pyproject.toml-based builds. "
+        "Run 'pip install -e .' to perform an editable install."
+    )
+    print(message)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` build-system configuration so editable installs use setuptools' PEP 517 backend
- replace the old `setup.py` installer with a compatibility shim that points users to `pip install -e .`

## Testing
- `pip install -e .` *(fails in this environment: proxy blocks downloading setuptools>=68)*

------
https://chatgpt.com/codex/tasks/task_e_68e0368deb208325a5c50ca18e63fe5d