### PR TITLE
Fix setup.py shim for editable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,15 @@
 """Compatibility shim for legacy installation workflows.
 
 This project is configured as a PEP 517/660 package using ``pyproject.toml``.
-Direct execution of ``setup.py`` is no longer supported. Please install the
-package in editable mode with ``pip install -e .``.
+Direct execution of ``setup.py`` is discouraged, but the file needs to keep
+working when tooling such as ``pip`` imports it to generate package metadata.
 """
 
 from __future__ import annotations
 
 import sys
+
+from setuptools import setup
 
 
 def main() -> None:
@@ -15,8 +17,15 @@ def main() -> None:
         "This project uses pyproject.toml-based builds. "
         "Run 'pip install -e .' to perform an editable install."
     )
+
+    if len(sys.argv) == 1:
+        print(message)
+        sys.exit(0)
+
+    # Allow build front-ends (for example ``pip``) to continue with the
+    # standard setuptools build process so metadata can be generated.
     print(message)
-    sys.exit(0)
+    setup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow the setup.py compatibility shim to invoke setuptools when build tools import it
- retain the user-facing guidance to prefer `pip install -e .`

## Testing
- pip install -e . *(fails in this environment due to proxy restrictions while downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e03d3cfbcc8325b05a0993261a6409