### PR TITLE
Process all rasters during polygon extraction

### DIFF
--- a/src/file_types.py
+++ b/src/file_types.py
@@ -1094,7 +1094,9 @@ class SpectralDataParquetFile(DataFile):
     def from_raster_file(cls, raster_file: DataFile) -> "SpectralDataParquetFile":
         base = raster_file.path.stem
         filename = f"{base}_spectral_data.parquet"
-        return cls(raster_file.path.parent / filename, base=base)
+        output_directory = raster_file.path.parent / "full_extracted_pixels"
+        output_directory.mkdir(parents=True, exist_ok=True)
+        return cls(output_directory / filename, base=base)
 
     @classmethod
     def from_filename(cls, path: Path) -> "SpectralDataParquetFile":


### PR DESCRIPTION
## Summary
- ensure polygon extraction processes every raster file in a directory while still prioritising BRDF-corrected data when duplicates exist
- write extracted spectral parquet outputs to a dedicated `full_extracted_pixels` folder and ensure the directory is created before writing

## Testing
- pytest tests/test_file_sort.py *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68e3e2c5054883258cdc7e3a737f14c5